### PR TITLE
Added option to add or remove colors

### DIFF
--- a/common.js
+++ b/common.js
@@ -1,7 +1,10 @@
 const DEBUG = true;
 const DISPLAY_DEBUG_TIME = false;
 const LIMIT_DELTA_TIME = 3; // In Seconds
+const googleGreen = "#009688";
+const googleAquaBlue = "#00BBD3";
 const crunchyrollOrange = "#F78C25";
+const defaultcolorOptions = [googleGreen, googleAquaBlue, crunchyrollOrange];
 
 const Actions = {
   PLAY: 'play',
@@ -63,8 +66,16 @@ function executeScript(tabId, obj) {
 
 function getExtensionColor() {
   return new Promise(callback => {
-    chrome.storage.sync.get({ 'extensionColor': crunchyrollOrange }, function (data) {
+    chrome.storage.sync.get({ extensionColor: crunchyrollOrange }, function (data) {
       callback(data.extensionColor);
+    });
+  });
+}
+
+function getColorMenu() {
+  return new Promise(callback => {
+    chrome.storage.sync.get({ colorOptions: defaultcolorOptions }, function (data) {
+      callback(data.colorOptions);
     });
   });
 }

--- a/options.html
+++ b/options.html
@@ -11,8 +11,12 @@
     <h2>Select a primary color for this extension</h2>
     <div id="colorSelector" class="mb16"></div>
       <input id="colorInput" type="text" value="">
-      <button class="mt16" id="submitButton">Change Color!</button>
-      <p id="confirmationMessage" class="c-error">
+      <div class="actionButtonContainer"> 
+        <button class="mt16 actionButton" id="addButton">Add Color</button>
+        <button class="mt16 actionButton" id="removeButton">Remove Color</button>
+      </div>
+      <p id="confirmationMessage" class="c-error"></p>
+    </div>  
   </div>
 </body>
 <script src="common.js"></script>

--- a/options.html
+++ b/options.html
@@ -11,9 +11,9 @@
     <h2>Select a primary color for this extension</h2>
     <div id="colorSelector" class="mb16"></div>
       <input id="colorInput" type="text" value="">
-      <div class="actionButtonContainer"> 
-        <button class="mt16 actionButton" id="addButton">Add Color</button>
-        <button class="mt16 actionButton" id="removeButton">Remove Color</button>
+      <div class="optionsButtonContainer"> 
+        <button class="mt16 optionButton" id="addButton">Add Color</button>
+        <button class="mt16 optionButton" id="removeButton">Remove Color</button>
       </div>
       <p id="confirmationMessage" class="c-error"></p>
     </div>  

--- a/options.js
+++ b/options.js
@@ -1,4 +1,4 @@
-const page = document.getElementById("colorSelector");
+const colorSelector = document.getElementById("colorSelector");
 let addButton = document.getElementById("addButton");
 let removeButton = document.getElementById("removeButton");
 const input = document.getElementById("colorInput");
@@ -15,7 +15,7 @@ function updateExtensionColor(color) {
 }
 
 function updateColorMenu(colorOptions) {
-  while(page.lastChild) page.removeChild(page.lastChild);
+  while(colorSelector.lastChild) colorSelector.removeChild(colorSelector.lastChild);
   buildButtons(colorOptions);
 }
 
@@ -110,11 +110,11 @@ function buildButtons(colorOptions) {
   for (let color of colorOptions) {
     let newButton = document.createElement("button");
     newButton.addEventListener("click", function () { 
-      setExtensionColor(color); 
+      setExtensionColor(color);
       updateExtensionColor(color);
     });
     newButton.style.backgroundColor = color;
     newButton.className = "colorChangeButton"
-    page.appendChild(newButton);
+    colorSelector.appendChild(newButton);
   }
 }

--- a/options.js
+++ b/options.js
@@ -1,4 +1,4 @@
-let page = document.getElementById('colorSelector');
+const page = document.getElementById("colorSelector");
 let addButton = document.getElementById("addButton");
 let removeButton = document.getElementById("removeButton");
 const input = document.getElementById("colorInput");
@@ -105,14 +105,6 @@ function setExtensionColor(color) {
     log("Setting extension color to " + color);
   });
 }
-
-input.addEventListener("keyup", function(event) {
-  if (event.keyCode === 13) {
-    event.preventDefault();
-    let color = input.value;
-    if(colorCodeValidation(color)) updateExtensionColor(color);
-  }
-});
 
 function buildButtons(colorOptions) {
   for (let color of colorOptions) {

--- a/options.js
+++ b/options.js
@@ -3,6 +3,7 @@ let addButton = document.getElementById("addButton");
 let removeButton = document.getElementById("removeButton");
 const input = document.getElementById("colorInput");
 const confirmationMessage = document.getElementById("confirmationMessage");
+const maxMenuSize = 10;
 
 getExtensionColor().then(color => updateExtensionColor(color));
 getColorMenu().then(colorOptions => buildButtons(colorOptions));
@@ -34,9 +35,15 @@ function colorCodeValidation(color) {
 addButton.onclick = function() {
   const color = input.value.toUpperCase();
 
-  if(!colorCodeValidation(color)) return;
-
   getColorMenu().then( colorOptions => {
+    if(colorOptions.length === maxMenuSize) {
+      confirmationMessage.innerText = "You have reached the maximum menu size!";
+      log("Max menu size reached");
+      return;
+    }
+
+    if(!colorCodeValidation(color)) return;
+
     const isInMenu = colorOptions.includes(color);
 
     if(isInMenu) {

--- a/options.js
+++ b/options.js
@@ -1,21 +1,15 @@
 let page = document.getElementById('colorSelector');
 
-const googleGreen = "#009688";
-const googleAquaBlue = "#00BBD3";
-
 const input = document.getElementById("colorInput");
-let submitButton = document.getElementById("submitButton");
+getExtensionColor().then(color => setExtensionColor(color));
+getColorMenu().then(colorOptions => buildButtons(colorOptions));
 
-getExtensionColor().then(color => {
-  input.value = color;
-  submitButton.style.backgroundColor = color;
-});
+let addButton = document.getElementById("addButton");
+let removeButton = document.getElementById("removeButton");
 
-const colorOptions = [ googleGreen, googleAquaBlue, crunchyrollOrange ];
-
-submitButton.onclick = function() {
-  let color = document.getElementById("colorInput").value;
-  let isOk = /^#[0-9A-F]{6}$/i.test(color);
+addButton.onclick = function() {
+  const color = document.getElementById("colorInput").value.toUpperCase();
+  const isOk = /^#([0-9A-F]{3}){1,2}$/i.test(color);
   const confirmationMessage = document.getElementById("confirmationMessage");
   confirmationMessage.innerText = "";
 
@@ -25,34 +19,93 @@ submitButton.onclick = function() {
     return;
   }
 
-  setExtensionColor(color);
-  log("Color changed to " + color);
+  getColorMenu().then( colorOptions => {
+    const isInMenu = colorOptions.includes(color);
+
+    if(isInMenu) {
+      confirmationMessage.innerText = "This color is already in the menu";
+      log("Repeated color");
+      return;
+    }
+
+    setExtensionColor(color);
+    colorOptions.push(color);
+
+    setColorMenu(colorOptions);
+    document.location.reload();
+
+  }); 
+}
+
+removeButton.onclick = function() {
+  const color = document.getElementById("colorInput").value.toUpperCase();
+  const isOk = /^#([0-9A-F]{3}){1,2}$/i.test(color);
+  const confirmationMessage = document.getElementById("confirmationMessage");
+  confirmationMessage.innerText = "";
+
+  if (!isOk) {
+    confirmationMessage.innerText = "Invalid hex code!";
+    log("Invalid input");
+    return;
+  }
+
+  if(color === crunchyrollOrange) {
+    confirmationMessage.innerText = "You can't remove this color!";
+    log("Tried to remove theme color");
+    return;
+  }
+
+  getColorMenu().then( colorOptions => {
+    const isInMenu = colorOptions.includes(color);
+
+    if(!isInMenu) {
+      confirmationMessage.innerText = "This color isn't in the menu";
+      log("Color not in menu");
+      return;
+    }
+
+    colorOptions = colorOptions.filter(function(element) { return element != color; });
+
+    getExtensionColor().then( currentColor => {
+      const isInMenu = colorOptions.includes(currentColor);
+      if(!isInMenu) setExtensionColor(crunchyrollOrange);
+    });
+
+    setColorMenu(colorOptions);
+    document.location.reload();
+
+  });
+}
+
+function setColorMenu(colorMenu) {
+  chrome.storage.sync.set({ colorOptions: colorMenu }, function () {
+    log("Removing " + color + " from the color menu");
+  });
 }
 
 function setExtensionColor(color) {
   chrome.storage.sync.set({ extensionColor: color }, function () {
     log("Setting extension color to " + color);
   });
-  submitButton.style.backgroundColor = color;
+
+  input.value = color;
+  addButton.style.backgroundColor = color;
+  removeButton.style.backgroundColor = color;
 }
 
 input.addEventListener("keyup", function(event) {
   if (event.keyCode === 13) {
     event.preventDefault();
-    submitButton.click();
+    document.getElementById("").click();
   }
 });
 
 function buildButtons(colorOptions) {
-  let page = document.getElementById("colorSelector");
-
   for (let color of colorOptions) {
     let newButton = document.createElement("button");
-    newButton.addEventListener("click", function () { input.value = color });
+    newButton.addEventListener("click", function () { setExtensionColor(color); });
     newButton.style.backgroundColor = color;
     newButton.className = "colorChangeButton"
     page.appendChild(newButton);
   }
 }
-
-buildButtons(colorOptions);

--- a/popup.js
+++ b/popup.js
@@ -15,7 +15,6 @@ chrome.storage.sync.get('extensionColor', function (data) {
   }
 });
 
-
 function executeScript(tabId, obj) {
   return new Promise(
     callback => chrome.tabs.executeScript(tabId, obj, callback)

--- a/styles.css
+++ b/styles.css
@@ -76,13 +76,13 @@ button {
   border-radius: 4px;
 }
 
-.actionButtonContainer {
+.optionsButtonContainer {
   display: inline-flex;
   width: 250px;
   justify-content: space-around;
 }
 
-.actionButton {
+.optionButton {
   display: flex;
   height: 41px;
   width: 100px;

--- a/styles.css
+++ b/styles.css
@@ -79,13 +79,14 @@ button {
 .optionsButtonContainer {
   display: inline-flex;
   width: 250px;
-  justify-content: space-around;
+  justify-content: space-evenly;
 }
 
 .optionButton {
   display: flex;
   height: 41px;
-  width: 100px;
+  width: auto;
+  padding: 10px;
   font-size: 14px;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -76,6 +76,19 @@ button {
   border-radius: 4px;
 }
 
+.actionButtonContainer {
+  display: inline-flex;
+  width: 250px;
+  justify-content: space-around;
+}
+
+.actionButton {
+  display: flex;
+  height: 41px;
+  width: 100px;
+  font-size: 14px;
+}
+
 input {
   padding: 0px;
   width: 75%;
@@ -95,6 +108,7 @@ input {
   margin-right: 8px;
   margin-left: 8px;
 }
+
 .colorChangeButton {
   border: 1px solid #333;
   height: 30px;


### PR DESCRIPTION
Implementation of add and remove color buttons, users can inform the hex code of a color and after pressing the "Add Color" button it will be created a button in the menu with the new color and the extension will change to this color, pressing the "Remove Color" button will remove the menu button of the color informed, the only color that can't be removed is crunchyrollOrange. 

Changes:

Created add and remove color buttons
Using Promises to get user chrome data
Removed change color button

Current options page:
![image](https://user-images.githubusercontent.com/42014408/84464093-f3bc1080-ac49-11ea-8df7-65566f41fa1b.png)
