### PR TITLE
Skip intro button

### DIFF
--- a/background.js
+++ b/background.js
@@ -5,19 +5,22 @@ window.updatePopup = null;
 let webPageConnection = null;
 let socket = null;
 let roomId = null;
+let skipIntro = true;
 
 loadStyles();
 
-chrome.tabs.onActivated.addListener(({tabId}) => getExtensionColor().then(color => setIconColor(tabId, color )));
+chrome.tabs.onActivated.addListener(({tabId}) => {
+  getExtensionColor().then(color => setIconColor(tabId, color ))
+  getIntroFeatureState().then(state => skipIntro = state);
+});
 
 chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
+  getIntroFeatureState().then(state => skipIntro = state);
+  console.log({ skipIntro });
   getExtensionColor().then(color => setIconColor(tabId, color ));
 
   if (roomId != null) return;
   if (!tab.url.startsWith('https://www.crunchyroll.com/')) return;
-
-  //window.setInterval(testIntroFeature, 10000);
-  //log('Updated Tab Triggered: 10s from now');
 
   const urlRoomId = getParameterByName(tab.url);
   log('Updated tab', { tab, urlRoomId });
@@ -54,14 +57,6 @@ function disconnectWebsocket() {
 
   tryUpdatePopup();
 }
-
-const testIntroFeature = () => {
-  if(webPageConnection) {
-    log('Called IntroFeature Requisition');
-    const type = BackgroundMessageTypes.SKIP_MARKS;
-    webPageConnection.postMessage({ type, marks: {begin: 10.0, end: 30.0 } });
-  }
-};
 
 chrome.runtime.onConnectExternal.addListener(port => {
   webPageConnection = port;

--- a/background.js
+++ b/background.js
@@ -16,6 +16,9 @@ chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
   if (roomId != null) return;
   if (!tab.url.startsWith('https://www.crunchyroll.com/')) return;
 
+  //window.setInterval(testIntroFeature, 10000);
+  //log('Updated Tab Triggered: 10s from now');
+
   const urlRoomId = getParameterByName(tab.url);
   log('Updated tab', { tab, urlRoomId });
   if (urlRoomId == null) return;
@@ -51,6 +54,14 @@ function disconnectWebsocket() {
 
   tryUpdatePopup();
 }
+
+const testIntroFeature = () => {
+  if(webPageConnection) {
+    log('Called IntroFeature Requisition');
+    const type = BackgroundMessageTypes.SKIP_MARKS;
+    webPageConnection.postMessage({ type, marks: {begin: 10.0, end: 30.0 } });
+  }
+};
 
 chrome.runtime.onConnectExternal.addListener(port => {
   webPageConnection = port;

--- a/common.js
+++ b/common.js
@@ -4,6 +4,7 @@ const LIMIT_DELTA_TIME = 3; // In Seconds
 const googleGreen = "#009688";
 const googleAquaBlue = "#00BBD3";
 const crunchyrollOrange = "#F78C25";
+const chineseSilver = "#CCC";
 const defaultcolorOptions = [googleGreen, googleAquaBlue, crunchyrollOrange];
 
 const Actions = {

--- a/common.js
+++ b/common.js
@@ -21,7 +21,8 @@ const States = {
 
 const BackgroundMessageTypes = {
   REMOTE_UPDATE: 'remote_update',
-  CONNECTION: 'connection'
+  CONNECTION: 'connection', 
+  SKIP_MARKS: 'skip_marks'
 }
 
 const WebpageMessageTypes = {

--- a/common.js
+++ b/common.js
@@ -80,3 +80,11 @@ function getColorMenu() {
     });
   });
 }
+
+function getIntroFeatureState() {
+  return new Promise(callback => {
+    chrome.storage.sync.get({ isIntroFeatureActive: true }, function (data) {
+      callback(data.isIntroFeatureActive);
+    });
+  });
+}

--- a/content_script.js
+++ b/content_script.js
@@ -8,8 +8,6 @@ if (document.getElementById('ROLL_TOGETHER_SCRIPT') == null) {
 
     let skipButton = null;
     let currentSkipButtonState = null;
-    
-    let isIntroFeatureActive = true;
 
     const skipButtonStates = {
       CONSTANT: 'constant', 
@@ -43,11 +41,9 @@ if (document.getElementById('ROLL_TOGETHER_SCRIPT') == null) {
     }
 
    const getSkipButtonState = (currentProgress) => {
-      if(!isIntroFeatureActive || !beginIntro) return skipButtonStates.HIDDEN;
+      if(!beginIntro) return skipButtonStates.HIDDEN;
 
       let endConstantStateTime = Math.min(endIntro, beginIntro + 5);
-
-      console.log({beginIntro, endIntro, endConstantStateTime, currentProgress});
 
       if(currentProgress >= beginIntro && currentProgress <= endConstantStateTime) {
         return skipButtonStates.CONSTANT;
@@ -128,7 +124,6 @@ if (document.getElementById('ROLL_TOGETHER_SCRIPT') == null) {
           rollTogetherExtension.postMessage({ type, state, currentProgress });
           break;
         case Actions.TIMEUPDATE:
-          console.log(currentSkipButtonState);
           setSkipButtonState(currentProgress);
           timeJump && rollTogetherExtension.postMessage({ type, state, currentProgress });
           break;
@@ -188,7 +183,6 @@ if (document.getElementById('ROLL_TOGETHER_SCRIPT') == null) {
         case BackgroundMessageTypes.SKIP_MARKS:
           const { marks } = args;
           const { begin, end } = marks;
-          console.log("Intro info received");
           beginIntro = begin;
           endIntro = end;
           break;

--- a/manifest.json
+++ b/manifest.json
@@ -10,6 +10,15 @@
     ],
     "persistent": true
   },
+  "content_scripts": [
+    {
+      "matches": [
+        "*://www.crunchyroll.com/*"
+      ], 
+      "css": ["styles.css"]
+    }
+  ], 
+
   "externally_connectable": {
     "matches": [
       "*://www.crunchyroll.com/*"

--- a/options.html
+++ b/options.html
@@ -8,6 +8,13 @@
 <body class="optionsBody mt32">
   <div class="optionsContainer">
     <h1 class="mt32 mb16">Roll Together Options</h1>
+    <h2>Skip Intro Feature</h2>
+    <div>
+      <label class="switch">
+        <input id="skipIntroCheckbox" type="checkbox" checked>
+        <span id="spanIntroCheckBox" class="slider round"></span>
+      </label>
+    </div>
     <h2>Select a primary color for this extension</h2>
     <div id="colorSelector" class="mb16"></div>
       <input id="colorInput" type="text" value="">

--- a/options.js
+++ b/options.js
@@ -4,11 +4,36 @@ let removeButton = document.getElementById("removeButton");
 const input = document.getElementById("colorInput");
 const confirmationMessage = document.getElementById("confirmationMessage");
 const maxMenuSize = 10;
+const skipIntroCheckBox = document.getElementById("skipIntroCheckbox");
+const spanIntroCheckBox = document.getElementById("spanIntroCheckBox");
+let extensionColor = null;
 
 getExtensionColor().then(color => updateExtensionColor(color));
 getColorMenu().then(colorOptions => buildButtons(colorOptions));
+getIntroFeatureState().then(state => skipIntroCheckBox.checked = state);
+
+function setCheckBoxColor() {
+  if(skipIntroCheckBox.checked) {
+    spanIntroCheckBox.style.backgroundColor = extensionColor;
+  } else {
+    spanIntroCheckBox.style.backgroundColor = chineseSilver;
+  }
+}
+
+skipIntroCheckBox.onclick = () => {
+  setCheckBoxColor();
+  setIntroFeatureState(skipIntroCheckBox.checked);
+}
+
+function setIntroFeatureState(state) {
+  chrome.storage.sync.set({ isIntroFeatureActive: state }, function () {
+    log("Setting intro feature state to " + state);
+  });
+}
 
 function updateExtensionColor(color) {
+  extensionColor = color;
+  setCheckBoxColor();
   input.value = color;
   addButton.style.backgroundColor = color;
   removeButton.style.backgroundColor = color;
@@ -35,7 +60,7 @@ function colorCodeValidation(color) {
 addButton.onclick = function() {
   const color = input.value.toUpperCase();
 
-  getColorMenu().then( colorOptions => {
+  getColorMenu().then(colorOptions => {
     if(colorOptions.length === maxMenuSize) {
       confirmationMessage.innerText = "You have reached the maximum menu size!";
       log("Max menu size reached");

--- a/popup.js
+++ b/popup.js
@@ -6,12 +6,12 @@ const copyUrlButton = document.getElementById('copyUrl');
 const disconnectButton = document.getElementById('disconnect');
 const urlInput = document.getElementById('urlInput');
 
-chrome.storage.sync.get('extensionColor', function (data) {
+getExtensionColor().then(color => {
   let optionButtons = document.getElementsByClassName("actionButton");
 
   for (button of optionButtons) {
-    log("Color of " + button.id + " is now " + data.extensionColor);
-    button.style.backgroundColor = data.extensionColor;
+    log("Color of " + button.id + " is now " + color);
+    button.style.backgroundColor = color;
   }
 });
 

--- a/styles.css
+++ b/styles.css
@@ -130,6 +130,7 @@ button {
 }
 
 .optionButton {
+  transition: .4s;
   display: flex;
   height: 41px;
   width: auto;

--- a/styles.css
+++ b/styles.css
@@ -105,6 +105,15 @@ input {
   border-radius: 4px;
 }
 
+#skipButton {
+  bottom: 80px;
+  position: absolute;
+  right: 20px;
+  background-color: rgba(0, 0, 0, 0.3);
+  border: 1px solid white;
+  transition: opacity 0.5s;
+}
+
 #colorSelector > * {
   margin-right: 8px;
   margin-left: 8px;

--- a/styles.css
+++ b/styles.css
@@ -24,6 +24,53 @@ body.optionsBody {
   justify-content: center;
 }
 
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 50px;
+  height: 30px;
+}
+
+.switch input { 
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0px;
+  left: 0px;
+  right: 0px;
+  bottom: 0px;
+  background-color: #ccc;
+  transition: .4s;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 23px;
+  width: 23px;
+  right: 23px;
+  bottom: 4px;
+  background-color: white;
+  transition: .4s;
+}
+
+input:checked + .slider:before {
+  transform: translateX(19px);
+}
+
+.slider.round {
+  border-radius: 40px;
+}
+
+.slider.round:before {
+  border-radius: 50%;
+}
+
 .optionsContainer {
   display: flex;
   flex-direction: column;
@@ -31,7 +78,7 @@ body.optionsBody {
   text-align: center;
   background-color: #FEFEFE;
   width: 500px;
-  height: 320px;
+  height: 410px;
   border-radius: 10px;
 }
 


### PR DESCRIPTION
Implementation of a skip intro button, the button only appears if the skip intro feature is activated and the back-end has informed the intro begin and end time. If the user presses the button, the reproduction time will jump to the intro end time.

The button has 3 exhibition modes:
Constant - button is always visible
Hover - button is only visible when the mouse is over it
Hidden - button isn't displayed

Exhibition times:
Constant - first 5 seconds of the intro
Hover - after the first 5 seconds, until the intro ends
Hidden - all other cases

In options, there is a toggle button to activate / deactivate the skip intro feature, if the user changes this option, the page responsible for the video reproduction needs to be reloaded to consider the new setting.

Main Changes:
Created skip intro button (on the video reproduction page)
Created toggle button to activate / deactivate skip intro feature (on the extension options page)

Skip intro button layout:
![image](https://user-images.githubusercontent.com/42014408/88574926-77bf3180-d019-11ea-9788-4397ebf5c7fa.png)

New options page layout:
![image](https://user-images.githubusercontent.com/42014408/88574964-8574b700-d019-11ea-8439-2fd736e0fff1.png)

