### PR TITLE
Exx/add skip intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,13 @@ You can download it from Chrome Store using the following link [https://chrome.g
 
 Instructions from https://developer.chrome.com/extensions/getstarted
 ## TODO
-- [ ] Create a Website
-- [ ] Improve structure to allow more than one tab at the same time
-- [ ] Work with autoplay
-- [ ] Improve Logo/Name
 - [x] Customizable Palette
+- [x] Improve Logo/Name
+- [x] Improve structure to allow more than one tab at the same time
+- [x] Skip Intro Feature
+- [ ] Firefox Browser Support
+- [ ] Work with autoplay
+- [ ] Create a Website
 
 ## Related Repos
 Backend repo: https://github.com/samuraiexx/roll_together_backend

--- a/background.js
+++ b/background.js
@@ -5,19 +5,22 @@ window.updatePopup = null;
 let webPageConnection = null;
 let socket = null;
 let roomId = null;
+let skipIntro = true;
 
 loadStyles();
 
-chrome.tabs.onActivated.addListener(({tabId}) => getExtensionColor().then(color => setIconColor(tabId, color )));
+chrome.tabs.onActivated.addListener(({tabId}) => {
+  getExtensionColor().then(color => setIconColor(tabId, color ))
+  getIntroFeatureState().then(state => skipIntro = state);
+});
 
 chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
+  getIntroFeatureState().then(state => skipIntro = state);
+  console.log({ skipIntro });
   getExtensionColor().then(color => setIconColor(tabId, color ));
 
   if (roomId != null) return;
   if (!tab.url.startsWith('https://www.crunchyroll.com/')) return;
-
-  //window.setInterval(testIntroFeature, 10000);
-  //log('Updated Tab Triggered: 10s from now');
 
   const urlRoomId = getParameterByName(tab.url);
   log('Updated tab', { tab, urlRoomId });
@@ -54,14 +57,6 @@ function disconnectWebsocket() {
 
   tryUpdatePopup();
 }
-
-const testIntroFeature = () => {
-  if(webPageConnection) {
-    log('Called IntroFeature Requisition');
-    const type = BackgroundMessageTypes.SKIP_MARKS;
-    webPageConnection.postMessage({ type, marks: {begin: 10.0, end: 30.0 } });
-  }
-};
 
 chrome.runtime.onConnectExternal.addListener(port => {
   webPageConnection = port;

--- a/background.js
+++ b/background.js
@@ -1,6 +1,6 @@
 'use strict';
 const tabsInfo = {};
-const skipIntro = true;
+let skipIntro = null;
 const skipIntroSocket = io('https://rt-skip-intro.azurewebsites.net');
 const skipIntroPendingRequests = {}
 
@@ -9,6 +9,7 @@ loadStyles();
 const regex = /http.*:\/\/www\.crunchyroll.*\/[^\/]+\/episode.*/;
 chrome.tabs.onActivated.addListener(({ tabId }) => {
   getExtensionColor().then(color => setIconColor(tabId, color));
+  getIntroFeatureState().then(state => skipIntro = state);
 });
 
 chrome.runtime.onInstalled.addListener(function () {
@@ -23,6 +24,7 @@ chrome.runtime.onInstalled.addListener(function () {
 });
 
 chrome.tabs.onUpdated.addListener(async function (tabId, changeInfo, tab) {
+  getIntroFeatureState().then(state => skipIntro = state);
   getExtensionColor().then(color => setIconColor(tabId, color));
 
   if (!regex.test(tab.url)) {

--- a/background.js
+++ b/background.js
@@ -232,7 +232,6 @@ skipIntroSocket.on('skip-marks', ({ url, marks, error }) => {
   }
 
   chrome.tabs.query({ url }, function (tabs) {
-
     tabs.forEach(tab => {
       try {
         const tabInfo = tabsInfo[tab.id];

--- a/background.js
+++ b/background.js
@@ -16,6 +16,9 @@ chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
   if (roomId != null) return;
   if (!tab.url.startsWith('https://www.crunchyroll.com/')) return;
 
+  //window.setInterval(testIntroFeature, 10000);
+  //log('Updated Tab Triggered: 10s from now');
+
   const urlRoomId = getParameterByName(tab.url);
   log('Updated tab', { tab, urlRoomId });
   if (urlRoomId == null) return;
@@ -51,6 +54,14 @@ function disconnectWebsocket() {
 
   tryUpdatePopup();
 }
+
+const testIntroFeature = () => {
+  if(webPageConnection) {
+    log('Called IntroFeature Requisition');
+    const type = BackgroundMessageTypes.SKIP_MARKS;
+    webPageConnection.postMessage({ type, marks: {begin: 10.0, end: 30.0 } });
+  }
+};
 
 chrome.runtime.onConnectExternal.addListener(port => {
   webPageConnection = port;

--- a/common.js
+++ b/common.js
@@ -4,6 +4,7 @@ const LIMIT_DELTA_TIME = 3; // In Seconds
 const googleGreen = "#009688";
 const googleAquaBlue = "#00BBD3";
 const crunchyrollOrange = "#F78C25";
+const chineseSilver = "#CCC";
 const defaultcolorOptions = [googleGreen, googleAquaBlue, crunchyrollOrange];
 
 const Actions = {

--- a/common.js
+++ b/common.js
@@ -84,7 +84,7 @@ function getColorMenu() {
 
 function getIntroFeatureState() {
   return new Promise(callback => {
-    chrome.storage.sync.get({ isIntroFeatureActive: true }, function (data) {
+    chrome.storage.sync.get({ isIntroFeatureActive: false }, function (data) {
       callback(data.isIntroFeatureActive);
     });
   });

--- a/common.js
+++ b/common.js
@@ -21,7 +21,8 @@ const States = {
 
 const BackgroundMessageTypes = {
   REMOTE_UPDATE: 'remote_update',
-  CONNECTION: 'connection'
+  CONNECTION: 'connection', 
+  SKIP_MARKS: 'skip_marks'
 }
 
 const WebpageMessageTypes = {

--- a/common.js
+++ b/common.js
@@ -22,7 +22,7 @@ const States = {
 
 const BackgroundMessageTypes = {
   REMOTE_UPDATE: 'remote_update',
-  CONNECTION: 'connection', 
+  CONNECTION: 'connection',
   SKIP_MARKS: 'skip_marks'
 }
 

--- a/common.js
+++ b/common.js
@@ -80,3 +80,11 @@ function getColorMenu() {
     });
   });
 }
+
+function getIntroFeatureState() {
+  return new Promise(callback => {
+    chrome.storage.sync.get({ isIntroFeatureActive: true }, function (data) {
+      callback(data.isIntroFeatureActive);
+    });
+  });
+}

--- a/content_script.js
+++ b/content_script.js
@@ -80,7 +80,7 @@ if (document.getElementById('ROLL_TOGETHER_SCRIPT') == null) {
       const videoContainer = document.getElementById("showmedia_video_player");
   
       if(videoContainer) {
-        console.log("Creating skip button...");
+        log("Creating skip button...");
   
         if(document.getElementById("skipButton") == null) {
           skipButton = document.createElement("button");
@@ -100,7 +100,7 @@ if (document.getElementById('ROLL_TOGETHER_SCRIPT') == null) {
 
           skipButton.onclick = () => triggerAction(Actions.TIMEUPDATE, endIntro);          
 
-          root.appendChild(skipButton);
+          videoContainer.appendChild(skipButton);
           setSkipButtonState();
         }
       }

--- a/content_script.js
+++ b/content_script.js
@@ -41,9 +41,9 @@ if (document.getElementById('ROLL_TOGETHER_SCRIPT') == null) {
     }
 
    const getSkipButtonState = (currentProgress) => {
-      if(!beginIntro) return skipButtonStates.HIDDEN;
+      if(beginIntro === null) return skipButtonStates.HIDDEN;
 
-      let endConstantStateTime = Math.min(endIntro, beginIntro + 5);
+      const endConstantStateTime = Math.min(endIntro, beginIntro + 5);
 
       if(currentProgress >= beginIntro && currentProgress <= endConstantStateTime) {
         return skipButtonStates.CONSTANT;
@@ -77,9 +77,9 @@ if (document.getElementById('ROLL_TOGETHER_SCRIPT') == null) {
     }
 
     const createSkipButton = () => {
-      const root = document.getElementById("showmedia_video_player");
+      const videoContainer = document.getElementById("showmedia_video_player");
   
-      if(root) {
+      if(videoContainer) {
         console.log("Creating skip button...");
   
         if(document.getElementById("skipButton") == null) {

--- a/content_script.js
+++ b/content_script.js
@@ -8,8 +8,6 @@ if (document.getElementById('ROLL_TOGETHER_SCRIPT') == null) {
 
     let skipButton = null;
     let currentSkipButtonState = null;
-    
-    let isIntroFeatureActive = true;
 
     const skipButtonStates = {
       CONSTANT: 'constant', 
@@ -43,11 +41,9 @@ if (document.getElementById('ROLL_TOGETHER_SCRIPT') == null) {
     }
 
    const getSkipButtonState = (currentProgress) => {
-      if(!isIntroFeatureActive || !beginIntro) return skipButtonStates.HIDDEN;
+      if(!beginIntro) return skipButtonStates.HIDDEN;
 
       let endConstantStateTime = Math.min(endIntro, beginIntro + 5);
-
-      console.log({beginIntro, endIntro, endConstantStateTime, currentProgress});
 
       if(currentProgress >= beginIntro && currentProgress <= endConstantStateTime) {
         return skipButtonStates.CONSTANT;
@@ -128,7 +124,6 @@ if (document.getElementById('ROLL_TOGETHER_SCRIPT') == null) {
           rollTogetherExtension.postMessage({ type, state, currentProgress });
           break;
         case Actions.TIMEUPDATE:
-          console.log(currentSkipButtonState);
           setSkipButtonState(currentProgress);
           timeJump && rollTogetherExtension.postMessage({ type, state, currentProgress });
           break;
@@ -188,7 +183,6 @@ if (document.getElementById('ROLL_TOGETHER_SCRIPT') == null) {
         case BackgroundMessageTypes.SKIP_MARKS:
           const { marks } = args;
           const { begin, end } = marks;
-          console.log("Intro info received");
           beginIntro = begin;
           endIntro = end;
           break;

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Roll Together",
-  "version": "1.0",
+  "version": "2.0",
   "description": "It's an extension that lets you and a friend synchronize your anime so you can watch together =]",
   "background": {
     "scripts": [
@@ -14,11 +14,12 @@
     {
       "matches": [
         "*://www.crunchyroll.com/*"
-      ], 
-      "css": ["styles.css"]
+      ],
+      "css": [
+        "styles.css"
+      ]
     }
-  ], 
-
+  ],
   "externally_connectable": {
     "matches": [
       "*://www.crunchyroll.com/*"

--- a/manifest.json
+++ b/manifest.json
@@ -10,6 +10,15 @@
     ],
     "persistent": true
   },
+  "content_scripts": [
+    {
+      "matches": [
+        "*://www.crunchyroll.com/*"
+      ], 
+      "css": ["styles.css"]
+    }
+  ], 
+
   "externally_connectable": {
     "matches": [
       "*://www.crunchyroll.com/*"

--- a/manifest.json
+++ b/manifest.json
@@ -30,7 +30,8 @@
     "tabs",
     "activeTab",
     "declarativeContent",
-    "*://www.crunchyroll.com/*"
+    "*://www.crunchyroll.com/*",
+    "*://rt-skip-intro.azurewebsites.net/*"
   ],
   "page_action": {
     "default_popup": "popup.html",
@@ -47,7 +48,7 @@
     "48": "images/get_started48.png",
     "128": "images/get_started128.png"
   },
-  "options_page": "options.html", 
+  "options_page": "options.html",
   "manifest_version": 2,
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArcGab+PzppC/+XejE0z7kusfAXlu5DA5nUgFsfMAhOaSdtuBHClmRt6Sxg4IBSADQ3IFX7CnrlS/wWEf2XheU+Ou1Uj7hKpEnI3ThCX6qJyz2GD200ywQmNVS++TOqoQV03nbfSUsHVLJm+HqYxZBlVVlmWk6mgjIwxjOI87DmUIx+VOjv+rtBYaaUg+38Ri/ROYiAFaewUfIQVFZuRuYHc5klg788rUmX4E2pl2e+UPFlzdfYatGBoVV2lQhP4g0NtfwvbOE6sOW3VDCAwrNyqz/3LDldIwyZHtYUOesvI/g0CrFi0faO0kkMJsTjGMyPLRwfnNau/TkKqLfCswxQIDAQAB"
 }

--- a/options.html
+++ b/options.html
@@ -8,10 +8,10 @@
 <body class="optionsBody mt32">
   <div class="optionsContainer">
     <h1 class="mt32 mb16">Roll Together Options</h1>
-    <h2>Skip Intro Feature</h2>
+    <h2>Skip Intro Feature (Beta)</h2>
     <div>
       <label class="switch">
-        <input id="skipIntroCheckbox" type="checkbox" checked>
+        <input id="skipIntroCheckbox" type="checkbox">
         <span id="spanIntroCheckBox" class="slider round"></span>
       </label>
     </div>

--- a/options.html
+++ b/options.html
@@ -8,6 +8,13 @@
 <body class="optionsBody mt32">
   <div class="optionsContainer">
     <h1 class="mt32 mb16">Roll Together Options</h1>
+    <h2>Skip Intro Feature</h2>
+    <div>
+      <label class="switch">
+        <input id="skipIntroCheckbox" type="checkbox" checked>
+        <span id="spanIntroCheckBox" class="slider round"></span>
+      </label>
+    </div>
     <h2>Select a primary color for this extension</h2>
     <div id="colorSelector" class="mb16"></div>
       <input id="colorInput" type="text" value="">

--- a/options.js
+++ b/options.js
@@ -8,9 +8,9 @@ const skipIntroCheckBox = document.getElementById("skipIntroCheckbox");
 const spanIntroCheckBox = document.getElementById("spanIntroCheckBox");
 let extensionColor = null;
 
+getIntroFeatureState().then(state => skipIntroCheckBox.checked = state);
 getExtensionColor().then(color => updateExtensionColor(color));
 getColorMenu().then(colorOptions => buildButtons(colorOptions));
-getIntroFeatureState().then(state => skipIntroCheckBox.checked = state);
 
 function setCheckBoxColor() {
   if(skipIntroCheckBox.checked) {

--- a/options.js
+++ b/options.js
@@ -4,11 +4,36 @@ let removeButton = document.getElementById("removeButton");
 const input = document.getElementById("colorInput");
 const confirmationMessage = document.getElementById("confirmationMessage");
 const maxMenuSize = 10;
+const skipIntroCheckBox = document.getElementById("skipIntroCheckbox");
+const spanIntroCheckBox = document.getElementById("spanIntroCheckBox");
+let extensionColor = null;
 
 getExtensionColor().then(color => updateExtensionColor(color));
 getColorMenu().then(colorOptions => buildButtons(colorOptions));
+getIntroFeatureState().then(state => skipIntroCheckBox.checked = state);
+
+function setCheckBoxColor() {
+  if(skipIntroCheckBox.checked) {
+    spanIntroCheckBox.style.backgroundColor = extensionColor;
+  } else {
+    spanIntroCheckBox.style.backgroundColor = chineseSilver;
+  }
+}
+
+skipIntroCheckBox.onclick = () => {
+  setCheckBoxColor();
+  setIntroFeatureState(skipIntroCheckBox.checked);
+}
+
+function setIntroFeatureState(state) {
+  chrome.storage.sync.set({ isIntroFeatureActive: state }, function () {
+    log("Setting intro feature state to " + state);
+  });
+}
 
 function updateExtensionColor(color) {
+  extensionColor = color;
+  setCheckBoxColor();
   input.value = color;
   addButton.style.backgroundColor = color;
   removeButton.style.backgroundColor = color;
@@ -35,7 +60,7 @@ function colorCodeValidation(color) {
 addButton.onclick = function() {
   const color = input.value.toUpperCase();
 
-  getColorMenu().then( colorOptions => {
+  getColorMenu().then(colorOptions => {
     if(colorOptions.length === maxMenuSize) {
       confirmationMessage.innerText = "You have reached the maximum menu size!";
       log("Max menu size reached");

--- a/popup.js
+++ b/popup.js
@@ -21,28 +21,27 @@ function executeScript(tabId, obj) {
 }
 
 function update() {
-  const roomId = background.window.getRoomId();
-  const connected = roomId != null;
-  log('Updating Popup...', { roomId, connected });
+  chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
+    const tab = tabs[0];
+    const roomId = background.window.getRoomId(tab.id);
+    const connected = roomId != null;
 
-  if (connected) {
-    chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
-      const roomId = background.window.getRoomId();
-      const url = updateQueryStringParameter(tabs[0].url, 'rollTogetherRoom', roomId)
+    log('Updating Popup...', { roomId, connected });
+
+    if (connected) {
+      const url = updateQueryStringParameter(tab.url, 'rollTogetherRoom', roomId)
       urlInput.value = url;
       urlInput.focus();
       urlInput.select();
-    });
 
-    [...document.getElementsByClassName('firstPage')].forEach(el => el.style.display = 'none');
-    [...document.getElementsByClassName('secondPage')].forEach(el => el.style = {});
-  } else {
-    [...document.getElementsByClassName('firstPage')].forEach(el => el.style = {});
-    [...document.getElementsByClassName('secondPage')].forEach(el => el.style.display = 'none');
-  }
+      [...document.getElementsByClassName('firstPage')].forEach(el => el.style.display = 'none');
+      [...document.getElementsByClassName('secondPage')].forEach(el => el.style = {});
+    } else {
+      [...document.getElementsByClassName('firstPage')].forEach(el => el.style = {});
+      [...document.getElementsByClassName('secondPage')].forEach(el => el.style.display = 'none');
+    }
+  });
 }
-background.window.updatePopup = update;
-update();
 
 window.addEventListener('beforeunload', () => {
   background.window.updatePopup = null;
@@ -50,7 +49,7 @@ window.addEventListener('beforeunload', () => {
 
 createRoomButton.onclick = async function () {
   log('Clicking CreateRoomButton');
-  chrome.tabs.query({ active: true, currentWindow: true }, async function (tabs) {
+  chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
     background.window.createRoom(tabs[0]);
   });
 };
@@ -64,8 +63,14 @@ copyUrlButton.onclick = function () {
 
 disconnectButton.onclick = function () {
   log('Clicking DisconnectButton');
-  background.window.disconnectRoom();
+  chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
+    background.window.disconnectRoom(tabs[0].id);
+  })
 }
 
 urlInput.onclick = function () {
 }
+
+background.window.updatePopup = update;
+
+update();

--- a/popup.js
+++ b/popup.js
@@ -7,7 +7,7 @@ const disconnectButton = document.getElementById('disconnect');
 const urlInput = document.getElementById('urlInput');
 let optionButtons = document.getElementsByClassName('actionButton');
 
-getExtensionColor().then( color => {
+getExtensionColor().then(color => {
   for (button of optionButtons) {
     log("Color of " + button.id + " is now " + color);
     button.style.backgroundColor = color;

--- a/styles.css
+++ b/styles.css
@@ -130,6 +130,7 @@ button {
 }
 
 .optionButton {
+  transition: .4s;
   display: flex;
   height: 41px;
   width: auto;

--- a/styles.css
+++ b/styles.css
@@ -105,6 +105,15 @@ input {
   border-radius: 4px;
 }
 
+#skipButton {
+  bottom: 80px;
+  position: absolute;
+  right: 20px;
+  background-color: rgba(0, 0, 0, 0.3);
+  border: 1px solid white;
+  transition: opacity 0.5s;
+}
+
 #colorSelector > * {
   margin-right: 8px;
   margin-left: 8px;

--- a/styles.css
+++ b/styles.css
@@ -24,6 +24,53 @@ body.optionsBody {
   justify-content: center;
 }
 
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 50px;
+  height: 30px;
+}
+
+.switch input { 
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0px;
+  left: 0px;
+  right: 0px;
+  bottom: 0px;
+  background-color: #ccc;
+  transition: .4s;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 23px;
+  width: 23px;
+  right: 23px;
+  bottom: 4px;
+  background-color: white;
+  transition: .4s;
+}
+
+input:checked + .slider:before {
+  transform: translateX(19px);
+}
+
+.slider.round {
+  border-radius: 40px;
+}
+
+.slider.round:before {
+  border-radius: 50%;
+}
+
 .optionsContainer {
   display: flex;
   flex-direction: column;
@@ -31,7 +78,7 @@ body.optionsBody {
   text-align: center;
   background-color: #FEFEFE;
   width: 500px;
-  height: 320px;
+  height: 410px;
   border-radius: 10px;
 }
 


### PR DESCRIPTION
Adds a skip intro feature as shown in this picture:
![image](https://user-images.githubusercontent.com/13491046/88604466-d56d7100-d04d-11ea-8ce1-aa229f6fc872.png)

Also adds a toggle button that enables this feature
![image](https://user-images.githubusercontent.com/13491046/88604472-d9998e80-d04d-11ea-9c83-8c36f9be2d5d.png)

On Background:
- Changes in the old structure so more than one tab can be open at the same time. Now the socketId and roomId are stored on tabsInfo so each tab can have their own room
- Adds a skipIntro option that loads whether or not the skipIntro actions should start when a page is loaded
- Adds a socket to connect to a server that will provide the skipIntro time marks


Flux: 
 - Somebody opens a Crunchyroll episode page
 - content_script is injected on the page
 - If skipIntro is true then background connects to the skipintro webservice and sends the current page url
- When the server answers back, sends a message to the webpage (read on the content_script) with the intro marks

Also, since the socketId changes whenever there is a connection fail, all the pending requests are stored and resent when the client disconnects

Other changes are described [here](https://github.com/samuraiexx/roll_together/pull/7)