### PR TITLE
Bug Fix - Change PageStateMatcher logic

### DIFF
--- a/background.js
+++ b/background.js
@@ -15,7 +15,8 @@ chrome.runtime.onInstalled.addListener(function () {
   chrome.declarativeContent.onPageChanged.removeRules(undefined, function () {
     chrome.declarativeContent.onPageChanged.addRules([{
       conditions: [new chrome.declarativeContent.PageStateMatcher({
-        pageUrl: { urlMatches: 'http.*:\/\/www\.crunchyroll.*\/[^\/]+\/episode.*' },
+        pageUrl: { urlMatches: "http.*:\/\/www\.crunchyroll.*\/[^\/]+\/.*" },
+        css: ["iframe#vilos-player"]
       })],
       actions: [new chrome.declarativeContent.ShowPageAction()]
     }]);


### PR DESCRIPTION
Someone reported in our development email that the popup wasn't working for a specific episode.
[Link](https://www.crunchyroll.com/rezero-starting-life-in-another-world-/rezero-starting-life-in-another-world-the-end-of-the-beginning-and-the-beginning-of-the-end-part-1-702401)

I noticed that the url doesn't have the work "episode" in it and thus not been accepted by the regular expression.
I've changed to a more reliable way.

I've tested on some links and in full screen, all working ok.
