### PR TITLE
Change PageStateMather to match iFrameSource

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -39,8 +39,10 @@ chrome.runtime.onInstalled.addListener(function () {
       {
         conditions: [
           new chrome.declarativeContent.PageStateMatcher({
-            pageUrl: { urlMatches: String.raw`http.?:\/\/[^\.]*\.crunchyroll\.` },
-            css: ["iframe#vilos-player"],
+            pageUrl: {
+              urlMatches: String.raw`http.?:\/\/[^\.]*\.crunchyroll\.`,
+            },
+            css: [`iframe[src*="static.crunchyroll.com"]`],
           }),
         ],
         actions: [new chrome.declarativeContent.ShowPageAction()],


### PR DESCRIPTION
Instead of matching the video IFrame ID, changed to match the source URL, that way removes the frame id dependency. 
It doesn't create a new dependency on "static.crunchyroll"

https://www.w3schools.com/css/css_attribute_selectors.asp#:~:text=The%20%5Battribute*%3D%22value%22,to%20be%20a%20whole%20word! -> Reference for CSS Selector

I hope it closes #14 