### PR TITLE
Add session token to episodes carousel

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -20,6 +20,15 @@
 			"js": [
 				"content_script.js"
 			]
+		},
+		{
+			"all_frames": false,
+			"matches": [
+				"*://www.crunchyroll.com/*"
+			],
+			"js": [
+				"root_content_script.js"
+			]
 		}
 	],
 	"content_security_policy": "script-src 'self' 'sha256-3Ysffha/L9RFJ1cEzjlxPSHl7yyXbbb05h9eNgaAqgE='; object-src 'self'",

--- a/src/root_content_script.ts
+++ b/src/root_content_script.ts
@@ -1,0 +1,49 @@
+function updateLinks(roomId: string) {
+  const links = document.querySelectorAll(
+    ".collection-carousel-media-link .link.block-link"
+  );
+
+  links.forEach((block: HTMLAnchorElement) => {
+    const blockUrl = new URL(block.href);
+    const blockParams = new URLSearchParams(blockUrl.search);
+
+    if (blockParams.get("rollTogetherRoom")) return;
+
+    block.href = `${block.href}?rollTogetherRoom=${roomId}`;
+  });
+}
+
+function observeCarousel(roomId: string) {
+  const carousel = document.querySelector(".collection-carousel-scrollable");
+  if (!carousel) return;
+
+  let inInterval = false;
+  const observer = new MutationObserver(() => {
+    if (inInterval) return;
+
+    updateLinks(roomId);
+    setTimeout(() => {
+      inInterval = false;
+    }, 500);
+
+    inInterval = true;
+  });
+
+  observer.observe(carousel, {
+    attributes: true,
+  });
+}
+
+function addSessionToLinks() {
+  const url = new URL(document.URL);
+  const params = new URLSearchParams(url.search);
+
+  const roomId = params.get("rollTogetherRoom");
+
+  if (!roomId) return;
+
+  updateLinks(roomId);
+  observeCarousel(roomId);
+}
+
+addSessionToLinks();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,7 @@ module.exports = (env) => {
       popup: "./src/popup.ts",
       options: "./src/options.ts",
       content_script: "./src/content_script.ts",
+      root_content_script: "./src/root_content_script.ts",
     },
     module: {
       rules: [


### PR DESCRIPTION
## Problem
When using the extension if I'm connected in someone else room and I click in the next episode I lost the session in my URL and I need to ask for another session link or add the `rollTogetherRoom` param manually.

## Description
This PR adds the `rollTogetherRoom` params in the episodes in the carousel. 
It also observe changes in the carousel and replace link without the param when the carousel is changed.

This is creating a new `content_script` that changing the DOM of the `www.crunchyroll.com` website, that is why I needed another content script.

Sorry for not creating a issue for this before, I fixed this in my PR so when I'm using I don't have this problem and decided to send you the code here if you have interest in this feature.
